### PR TITLE
Delay sunshine and x11vnc startups to avoid conflicts with Batocera's X server

### DIFF
--- a/sunshine/sunshine.sh
+++ b/sunshine/sunshine.sh
@@ -29,8 +29,10 @@ cat << 'EOF' > /userdata/system/services/sunshine
 # sunshine service script for Batocera
 # Functional start/stop/restart/status (update)/uninstall
 
+MIN_SECS_AFTER_BOOT_SEQUENCE=60
+
 # Environment setup
-export $(cat /proc/1/environ | tr '\0' '\n')
+export $(tr '\0' '\n' < /proc/1/environ)
 export DISPLAY=:0.0
 export HOME=/userdata/system/add-ons/sunshine
 
@@ -54,6 +56,9 @@ case "$1" in
 
         # Start Sunshine AppImage
         if [ -x "${app_image}" ]; then
+            # Leave enough time to boot sequence after running this service to avoid messing up with X server's startup
+            # If system has been running past boot time, start right away
+            [ "$(cut -d. -f1 /proc/uptime)" -lt $MIN_SECS_AFTER_BOOT_SEQUENCE ] && sleep $MIN_SECS_AFTER_BOOT_SEQUENCE
             cd "${app_dir}"
             ./sunshine.AppImage > "${log_file}" 2>&1 &
             echo "Sunshine started successfully."

--- a/x11vnc/extra/x11vnc
+++ b/x11vnc/extra/x11vnc
@@ -1,24 +1,28 @@
 #!/bin/bash
 
+MIN_SECS_AFTER_BOOT_SEQUENCE=60
 STOP_FILE="/tmp/x11vnc.stop"
 LOG_FILE="/userdata/system/logs/x11vnc.log"
 RUN_CMD="x11vnc -display :0 -rfbport 5900 -reopen -forever -shared -logappend $LOG_FILE"
 
 case "$1" in
     start)
-	# Remove stop file
+	      # Remove stop file
         [ -f $STOP_FILE ] && rm $STOP_FILE
 
         # Ensure no new instances are spawned if already running
-        [[ $(pgrep -f "$RUN_CMD" > /dev/null) ]] && exit 0
+        pgrep -f "$RUN_CMD" > /dev/null && exit 0
 
         (
-	    while [ ! -f $STOP_FILE ]; do
+          # Leave enough time to boot sequence after running this service to avoid messing up with X server's startup
+          # If system has been running past boot time, start right away
+          [ "$(cut -d. -f1 /proc/uptime)" -lt $MIN_SECS_AFTER_BOOT_SEQUENCE ] && sleep $MIN_SECS_AFTER_BOOT_SEQUENCE
+	        while [ ! -f $STOP_FILE ]; do
                 echo "$(date) Starting x11vnc..." | tee -a "$LOG_FILE"
                 $RUN_CMD
-            done
-            echo "$(date) Stop file found" | tee -a "$LOG_FILE"
-        )&
+          done
+          echo "$(date) Stop file found" | tee -a "$LOG_FILE"
+        ) &
         ;;
     stop)
         echo "$(date) Stopping x11vnc..." | tee -a "$LOG_FILE"


### PR DESCRIPTION
Through many tests I've noticed this services sometimes interfere with batocera's X server initialization resulting in boot errors